### PR TITLE
Migrated Products to API endpoints

### DIFF
--- a/src/components/modals/product-editor/ProductEditor.svelte
+++ b/src/components/modals/product-editor/ProductEditor.svelte
@@ -7,7 +7,6 @@
 	import { page } from '$app/stores'
 	import Button from '$components/button/Button.svelte'
 	import Modal from '$components/modals/Modal.svelte'
-	import pocketbase from '$lib/backend'
 	import { parseFileUrl } from '$lib/files'
 	import UserStore from '$stores/user'
 
@@ -59,10 +58,24 @@
 			try {
 				if (product) {
 					if (hasRemovedImage)
-						await pocketbase.collection('products').update(product.id, { image: null })
+						await fetch(`/api/product/${product.id}`, {
+							method: 'PATCH',
+							body: JSON.stringify({ product: { image: null } })
+						})
 
-					await pocketbase.collection('products').update(product.id, formData)
-				} else await pocketbase.collection('products').create(formData)
+					await fetch(`/api/product/${product.id}`, {
+						method: 'PATCH',
+						headers: { 'content-type': 'multipart/form-data' },
+						body: formData
+					})
+				} else {
+					console.log('create')
+					await fetch('/api/product', {
+						method: 'POST',
+						headers: { 'content-type': 'multipart/form-data' },
+						body: formData
+					})
+				}
 				goto($page.url, { replaceState: true, invalidateAll: true })
 				closeModal()
 			} catch (e: any) {

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -8,7 +8,13 @@ pocketbase.authStore.onChange(async () => {
 		UserStore.set(await pocketbase.collection('users').getOne<User>(model.id))
 		document.cookie = pocketbase.authStore.exportToCookie({ httpOnly: false })
 	} else {
-		UserStore.set(null)
 		document.cookie = ''
 	}
 })
+
+const model = pocketbase.authStore?.model
+if (model)
+	pocketbase
+		.collection('users')
+		.getOne<User>(model.id)
+		.then((data) => UserStore.set(data))

--- a/src/routes/(app)/product/+page.svelte
+++ b/src/routes/(app)/product/+page.svelte
@@ -34,12 +34,11 @@
 	let totalPages: number
 
 	$: {
-		const { items, page, paginated, count, pages } = data
-		products = items
-		currentPage = page
-		perPage = paginated
-		totalItems = count
-		totalPages = pages
+		products = data.products
+		totalItems = data.count
+		totalPages = data.pages
+		currentPage = data.page
+		perPage = data.paginated
 	}
 
 	const categories = ['food', 'drink', 'meal', 'other']

--- a/src/routes/(app)/search/+page.svelte
+++ b/src/routes/(app)/search/+page.svelte
@@ -45,12 +45,11 @@
 	export let data: PageData
 
 	$: {
-		const { items, page, count, paginated, pages } = data
-		products = items
-		currentPage = page
-		perPage = paginated
-		totalItems = count
-		totalPages = pages
+		products = data.products
+		totalItems = data.count
+		totalPages = data.pages
+		currentPage = data.page
+		perPage = data.paginated
 	}
 
 	const categories = ['food', 'drink', 'meal', 'other']

--- a/src/routes/(dashboard)/merchant/products/+page.svelte
+++ b/src/routes/(dashboard)/merchant/products/+page.svelte
@@ -3,6 +3,7 @@
 	import { openModal } from 'svelte-modals'
 	import { MagnifyingGlass, Plus, XMark } from '@steeze-ui/heroicons'
 	import { Icon } from '@steeze-ui/svelte-icon'
+	import { toast } from '@zerodevx/svelte-toast'
 	import { goto } from '$app/navigation'
 	import { page } from '$app/stores'
 	import Dropdown from '$components/dropdown/Dropdown.svelte'
@@ -11,22 +12,20 @@
 	import Pagination from '$components/pagination/Pagination.svelte'
 	import ProductTable from '$components/product-table/ProductTable.svelte'
 	import Switch from '$components/switch/Switch.svelte'
-	import pocketbase from '$lib/backend'
 	import type { PageData } from './$types'
 
 	export let data: PageData
 
 	$: {
-		const { items, page, paginated, count, pages, store } = data
-		products = items
-		currentPage = page
-		perPage = paginated
-		totalItems = count
-		totalPages = pages
-		userStore = store
+		products = data.products
+		totalItems = data.count
+		totalPages = data.pages
+		currentPage = data.page
+		perPage = data.paginated
+		store = data.store
 	}
 	let products: Product[] = []
-	let userStore: Store
+	let store: Store
 	let totalItems: number
 	let totalPages: number
 	let currentPage: number
@@ -34,12 +33,12 @@
 	let sort: Kantina.ProductSort = { field: 'name', direction: 'ascending' }
 	let hideItems: boolean = false
 
-	const onTriggerAdd = () => openModal(ProductModal, { store: userStore })
+	const onTriggerAdd = () => openModal(ProductModal, { store: store })
 	const onTriggerEdit = (event: CustomEvent) => {
 		const product = event.detail
 		openModal(ProductModal, {
 			product,
-			store: userStore
+			store: store
 		})
 	}
 	const onTriggerRemove = (event: CustomEvent) => {
@@ -52,10 +51,10 @@
 			abandonText: 'Cancel',
 			confirm: async () => {
 				try {
-					await pocketbase.collection('products').delete(product.id)
+					await fetch(`/api/product/${product.id}`, { method: 'DELETE' })
 					goto($page.url, { replaceState: true, invalidateAll: true })
 				} catch (e) {
-					console.error(e)
+					toast.push('Error removing product')
 				}
 			}
 		})

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,10 +1,13 @@
-<script>
-	import { Icon } from '@steeze-ui/svelte-icon'
+<script lang="ts">
 	import { ArrowRight } from '@steeze-ui/heroicons'
+	import { Icon } from '@steeze-ui/svelte-icon'
 	import { page } from '$app/stores'
-	import Navigation from '$components/navigation/Navigation.svelte'
 	import Footer from '$components/footer/Footer.svelte'
+	import Navigation from '$components/navigation/Navigation.svelte'
+	import type { PageData } from './$types'
 
+	export let data: PageData
+	let user = data.user
 	let src = '/images/generic-error.svg'
 	let title = 'Oh no!'
 	let message = ''
@@ -22,7 +25,7 @@
 </script>
 
 <header>
-	<Navigation />
+	<Navigation {user} />
 </header>
 <div class="page w-full">
 	<div class="flex flex-col md:flex-row py-12 md:py-32">

--- a/src/routes/+layout.server.ts
+++ b/src/routes/+layout.server.ts
@@ -1,36 +1,38 @@
-import { authRoutes, privateRoutes } from "$shared/routes";
-import UserStore from "$stores/user";
-import { error, redirect } from "@sveltejs/kit";
-import type { LayoutServerLoad } from "./$types";
+import { error, redirect } from '@sveltejs/kit'
+import { authRoutes, privateRoutes } from '$shared/routes'
+import UserStore from '$stores/user'
+import type { LayoutServerLoad } from './$types'
 
-export const load = (async ({ locals, url }) => {
-  const pathname = url.pathname
+export const load: LayoutServerLoad = async ({ locals, url }) => {
+	const pathname = url.pathname
 
-  if (locals.user) {
-    if (authRoutes.includes(pathname)) {
-      throw redirect(303, '/')
-    }
+	if (locals.user) {
+		if (authRoutes.includes(pathname)) {
+			throw redirect(303, '/')
+		}
 
-    const user: User = JSON.parse(JSON.stringify(locals.user))
-    UserStore.set(user)
+		const user: User = JSON.parse(JSON.stringify(locals.user))
+		UserStore.set(user)
 
-    try {
-      const basket: CartItem[] = await locals.pocketbase.collection('carts').getFullList(undefined, {
-				filter: `user="${user.id}"`,
-				expand: 'product'
-			})
+		try {
+			const basket: CartItem[] = await locals.pocketbase
+				.collection('carts')
+				.getFullList(undefined, {
+					filter: `user="${user.id}"`,
+					expand: 'product'
+				})
 
-      return { user, cart: basket }
-    } catch (e) {
-      if (e instanceof Error) throw error(401, e.message)
+			return { user, cart: basket }
+		} catch (e) {
+			if (e instanceof Error) throw error(401, e.message)
 
-      throw error(500, 'Internal Server Error')
-    }
-  } else {
-    if (privateRoutes.includes(pathname)) {
-      throw redirect(303, '/')
-    }
+			throw error(500, 'Internal Server Error')
+		}
+	} else {
+		if (privateRoutes.includes(pathname)) {
+			throw redirect(303, '/')
+		}
 
-    return { user: null, cart: [] }
-  }
-}) satisfies LayoutServerLoad;
+		return { user: null, cart: [] }
+	}
+}

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,22 +1,23 @@
-import type { ListResult } from 'pocketbase'
 import { error } from '@sveltejs/kit'
-import pocketbase from '$lib/backend'
 import type { PageLoad } from './$types'
 
-export const load = (async () => {
+export const load: PageLoad = async ({ fetch }) => {
 	try {
-		const result: ListResult<Product> = await pocketbase.collection('products').getList(1, 5, {
-			filter: 'visible = true',
-			expand: 'store',
-			sort: '+updated'
+		const response = await fetch('/api/product/search', {
+			method: 'POST',
+			body: JSON.stringify({
+				page: 1,
+				limit: 5,
+				filter: ['visible = true'],
+				sort: ['+updated']
+			})
 		})
 
-		return {
-			products: result.items
-		}
+		const data = await response.json()
+		return data
 	} catch (e) {
 		if (e instanceof Error) throw error(401, e.message)
 
 		throw error(500, 'Internal Error')
 	}
-}) satisfies PageLoad
+}

--- a/src/routes/api/checkout/+server.ts
+++ b/src/routes/api/checkout/+server.ts
@@ -1,26 +1,26 @@
-import pocketbase from "$lib/backend";
-import { error, json } from "@sveltejs/kit";
-import type { RequestHandler } from "./$types";
+import { error, json } from '@sveltejs/kit'
+import pocketbase from '$lib/backend'
+import type { RequestHandler } from './$types'
 
-export const POST = (async ({ request }) => {
- try {
-	const { products, order, cart } = await request.json();
-	const basket: CartItem[] = cart
-	const orderedProducts: { [key: string]: number} = products
-	
-	for (const [key, value] of Object.entries(orderedProducts)) {
-		const product = await pocketbase.collection('products').getOne(key)
-		const quantity = product.quantity - value
-		await pocketbase.collection('products').update(key, { quantity })
+export const POST: RequestHandler = async ({ request }) => {
+	try {
+		const { products, order, cart } = await request.json()
+		const basket: CartItem[] = cart
+		const orderedProducts: { [key: string]: number } = products
+
+		for (const [key, value] of Object.entries(orderedProducts)) {
+			const product = await pocketbase.collection('products').getOne(key)
+			const quantity = product.quantity - value
+			await pocketbase.collection('products').update(key, { quantity })
+		}
+		for (const item of basket) {
+			await pocketbase.collection('carts').delete(item.id)
+		}
+
+		await pocketbase.collection('orders').create(order)
+		return json({ status: 200 })
+	} catch (e) {
+		console.error(e)
+		throw error(401, 'Internal Server Error')
 	}
-	for (const item of basket) {
-		await pocketbase.collection('carts').delete(item.id)
-	}
-	
-	await pocketbase.collection('orders').create(order)
-	return json({ status: 200 });
- } catch (e) {
-	console.error(e)
-	throw error(401, 'Internal Server Error')
- }
-}) satisfies RequestHandler;
+}

--- a/src/routes/api/product/+server.ts
+++ b/src/routes/api/product/+server.ts
@@ -1,0 +1,41 @@
+import { ClientResponseError, ListResult, type RecordQueryParams } from 'pocketbase'
+import { error, json } from '@sveltejs/kit'
+import pocketbase from '$lib/backend'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async ({ url }) => {
+	try {
+		const urlParams = url.searchParams
+		const page = parseInt(urlParams.get('page') ?? '1')
+		const limit = parseInt(urlParams.get('limit') ?? '10')
+
+		const data: ListResult<Product> = await pocketbase.collection('products').getList(page, limit)
+
+		return json({
+			products: data.items,
+			count: data.totalItems,
+			pages: data.totalPages,
+			page: data.page,
+			paginated: data.perPage
+		})
+	} catch (e) {
+		console.error(e)
+		if (e instanceof ClientResponseError) return json({ error: e })
+
+		throw error(500, 'Internal Server Error')
+	}
+}
+
+export const POST: RequestHandler = async ({ request }) => {
+	try {
+		const product = await request.formData()
+
+		await pocketbase.collection('products').create(product)
+		return json({ status: 200 })
+	} catch (e) {
+		console.error(e)
+		if (e instanceof ClientResponseError) return json({ error: e })
+
+		throw error(500, 'Internal Server Error')
+	}
+}

--- a/src/routes/api/product/[id]/+server.ts
+++ b/src/routes/api/product/[id]/+server.ts
@@ -1,0 +1,52 @@
+import { ClientResponseError } from 'pocketbase'
+import { error, json } from '@sveltejs/kit'
+import pocketbase from '$lib/backend'
+import type { RequestHandler } from './$types'
+
+export const GET: RequestHandler = async ({ params }) => {
+	try {
+		const id = params.id
+		const product = await pocketbase.collection('products').getOne(id, {
+			expand: 'store'
+		})
+		return json({ product })
+	} catch (e) {
+		console.error(e)
+		if (e instanceof ClientResponseError) return json({ error: e })
+
+		throw error(500, 'Internal Server Error')
+	}
+}
+
+export const PATCH: RequestHandler = async ({ params, request }) => {
+	try {
+		const id = params.id
+		let product
+
+		const type = request.headers.get('content-type')
+		if (type === 'multipart/form-data') product = await request.formData()
+		else product = await request.json()
+
+		await pocketbase.collection('products').update(id, product)
+		return json({ status: 200 })
+	} catch (e) {
+		console.error(e)
+		if (e instanceof ClientResponseError) return json({ error: e })
+
+		throw error(500, 'Internal Server Error')
+	}
+}
+
+export const DELETE: RequestHandler = async ({ params }) => {
+	try {
+		const id = params.id
+
+		await pocketbase.collection('products').delete(id)
+		return json({ status: 200 })
+	} catch (e) {
+		console.error(e)
+		if (e instanceof ClientResponseError) return json({ error: e })
+
+		throw error(500, 'Internal Server Error')
+	}
+}

--- a/src/routes/api/product/search/+server.ts
+++ b/src/routes/api/product/search/+server.ts
@@ -1,0 +1,34 @@
+import { ClientResponseError, ListResult, type RecordListQueryParams } from 'pocketbase'
+import { error, json } from '@sveltejs/kit'
+import pocketbase from '$lib/backend'
+import type { RequestHandler } from './$types'
+
+export const POST: RequestHandler = async ({ request }) => {
+	try {
+		const { page, limit, filter, sort } = await request.json()
+
+		const queryParams: RecordListQueryParams = {
+			expand: 'store'
+		}
+
+		if (filter && filter.length) queryParams.filter = filter.join(' && ')
+		if (sort && sort.length) queryParams.sort = sort.join(' && ')
+
+		const result: ListResult<Product> = await pocketbase
+			.collection('products')
+			.getList(page, limit, queryParams)
+
+		return json({
+			products: result.items,
+			count: result.totalItems,
+			pages: result.totalPages,
+			page: result.page,
+			paginated: result.perPage
+		})
+	} catch (e) {
+		console.error(e)
+		if (e instanceof ClientResponseError) return json({ error: e })
+
+		throw error(500, 'Internal Server Error')
+	}
+}


### PR DESCRIPTION
This PR introduces the migration on some page's `load()` function to an custom endpoint in the `api` folder rather than querying the database in the `load()` function itself. 