### PR TITLE
Migrate ratings to API Endpoint

### DIFF
--- a/src/components/modals/feedback-editor/FeedbackEditor.svelte
+++ b/src/components/modals/feedback-editor/FeedbackEditor.svelte
@@ -4,7 +4,6 @@
 	import { Icon } from '@steeze-ui/svelte-icon'
 	import { toast } from '@zerodevx/svelte-toast'
 	import Button from '$components/button/Button.svelte'
-	import pocketbase from '$lib/backend'
 	import UserStore from '$stores/user'
 	import Modal from '../Modal.svelte'
 

--- a/src/components/modals/feedback-editor/FeedbackEditor.svelte
+++ b/src/components/modals/feedback-editor/FeedbackEditor.svelte
@@ -22,15 +22,18 @@
 
 		isWorking = true
 		try {
-			const feedback = {
-				rating,
-				title,
-				description,
-				product: product.id,
-				user: user.id
-			}
-
-			await pocketbase.collection('ratings').create<Rating>(feedback)
+			await fetch('/api/rating', {
+				method: 'POST',
+				body: JSON.stringify({
+					rating: {
+						rating,
+						title,
+						description,
+						product: product.id,
+						user: user.id
+					}
+				})
+			})
 			toast.push('Feedback submitted')
 
 			closeModal()

--- a/src/routes/(app)/product/[id]/+page.svelte
+++ b/src/routes/(app)/product/[id]/+page.svelte
@@ -24,10 +24,15 @@
 	const productId = $page.params.id
 	const { product, related } = data
 	const outOfStock = product.quantity < 1
+
+	let ratings: Rating[]
 	let averageRating: number = 0
 
+	$: {
+		ratings = data.ratings
+	}
+
 	let basket: CartItem[] = data.cart
-	let ratings: Rating[] = data.ratings
 
 	let quantity: number = 1
 	const decrement = () => quantity - 1 > 0 && quantity--

--- a/src/routes/(app)/product/[id]/+page.ts
+++ b/src/routes/(app)/product/[id]/+page.ts
@@ -3,7 +3,7 @@ import { error } from '@sveltejs/kit'
 import pocketbase from '$lib/backend'
 import type { PageLoad } from './$types'
 
-export const load: PageLoad = async ({ params, fetch }) => {
+export const load: PageLoad = async ({ url, params, fetch }) => {
 	try {
 		let response = await fetch(`/api/product/${params.id}`, {
 			method: 'GET'
@@ -18,13 +18,17 @@ export const load: PageLoad = async ({ params, fetch }) => {
 		})
 		const data = await response.json()
 
+		url.searchParams.append('id', params.id)
+		response = await fetch('/api/rating?' + url.searchParams, {
+			method: 'GET'
+		})
+
+		const { ratings } = await response.json()
+
 		return {
-			product,
 			related: data.products,
-			ratings: await pocketbase.collection('ratings').getFullList<Rating>(undefined, {
-				filter: `product="${params.id}"`,
-				expand: 'user'
-			})
+			product,
+			ratings
 		}
 	} catch (e) {
 		if (e instanceof ClientResponseError) {

--- a/src/routes/api/rating/+server.ts
+++ b/src/routes/api/rating/+server.ts
@@ -8,11 +8,14 @@ export const GET: RequestHandler = async ({ url }) => {
 		const urlParams = url.searchParams
 		const page = parseInt(urlParams.get('page') ?? '1')
 		const limit = parseInt(urlParams.get('limit') ?? '10')
+		const id = urlParams.get('id')
 
-		const data: ListResult<Product> = await pocketbase.collection('products').getList(page, limit)
+		const data: ListResult<Rating> = await pocketbase
+			.collection('ratings')
+			.getList(page, limit, { filter: `product="${id}"`, expand: 'user' })
 
 		return json({
-			products: data.items,
+			ratings: data.items,
 			count: data.totalItems,
 			pages: data.totalPages,
 			page: data.page,
@@ -28,9 +31,10 @@ export const GET: RequestHandler = async ({ url }) => {
 
 export const POST: RequestHandler = async ({ request }) => {
 	try {
-		const product = await request.formData()
+		const { rating } = await request.json()
 
-		await pocketbase.collection('products').create(product)
+		await pocketbase.collection('ratings').create(rating)
+
 		return json({ status: 200 })
 	} catch (e) {
 		console.error(e)

--- a/src/routes/api/rating/+server.ts
+++ b/src/routes/api/rating/+server.ts
@@ -12,7 +12,7 @@ export const GET: RequestHandler = async ({ url }) => {
 
 		const data: ListResult<Rating> = await pocketbase
 			.collection('ratings')
-			.getList(page, limit, { filter: `product="${id}"`, expand: 'user' })
+			.getList(page, limit, { expand: 'user', filter: `product="${id}"` })
 
 		return json({
 			ratings: data.items,


### PR DESCRIPTION
This PR introduces the continuation migration on some page's `load()` function to an custom endpoint in the `api` folder rather than querying the database in the `load()` function itself.